### PR TITLE
Adding accessors to `AccessGlobal` and `AccessIntsanceGlobal`

### DIFF
--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/global/AccessGlobal.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/global/AccessGlobal.java
@@ -50,6 +50,25 @@ public class AccessGlobal extends Expression {
 		this.target = target;
 	}
 
+	/**
+	 * Yields the {@link Unit} where the global targeted by this access is
+	 * defined.
+	 * 
+	 * @return the container of the global
+	 */
+	public Unit getContainer() {
+		return container;
+	}
+
+	/**
+	 * Yields the {@link Global} targeted by this expression.
+	 * 
+	 * @return the global
+	 */
+	public Global getTarget() {
+		return target;
+	}
+
 	@Override
 	public int setOffset(int offset) {
 		return this.offset = offset;

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/global/AccessInstanceGlobal.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/cfg/statement/global/AccessInstanceGlobal.java
@@ -54,6 +54,25 @@ public class AccessInstanceGlobal extends Expression {
 		receiver.setParentStatement(this);
 	}
 
+	/**
+	 * Yields the expression that determines the receiver of the global access
+	 * defined by this expression.
+	 * 
+	 * @return the receiver of the access
+	 */
+	public Expression getReceiver() {
+		return receiver;
+	}
+
+	/**
+	 * Yields the instance {@link Global} targeted by this expression.
+	 * 
+	 * @return the global
+	 */
+	public Global getTarget() {
+		return target;
+	}
+
 	@Override
 	public int setOffset(int offset) {
 		return this.offset = offset;


### PR DESCRIPTION
**Description**
Classes `AccessGlobal` and `AccessInstanceGlobal` miss accessors to their target and other relevant fields. This pull request adds these accessors.

**Fixed bugs**
Closes #143 
