### PR TITLE
Corrected translation of GreaterOrEqual and GreaterThan operators in Interval domain

### DIFF
--- a/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/numeric/Interval.java
+++ b/lisa/lisa-core/src/main/java/it/unive/lisa/analysis/numeric/Interval.java
@@ -304,9 +304,9 @@ public class Interval extends BaseNonRelationalValueDomain<Interval> {
 				return Satisfiability.SATISFIED;
 			return Satisfiability.UNKNOWN;
 		} else if (operator == ComparisonGe.INSTANCE)
-			return satisfiesBinaryExpression(ComparisonLt.INSTANCE, right, left, pp);
-		else if (operator == ComparisonGt.INSTANCE)
 			return satisfiesBinaryExpression(ComparisonLe.INSTANCE, right, left, pp);
+		else if (operator == ComparisonGt.INSTANCE)
+			return satisfiesBinaryExpression(ComparisonLt.INSTANCE, right, left, pp);
 		else if (operator == ComparisonLe.INSTANCE) {
 			Interval glb = null;
 			try {


### PR DESCRIPTION
This pull request fixes #235.
