### PR TITLE
Bug fix on CharacterInclusion

### DIFF
--- a/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/CharInclusion.java
+++ b/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/CharInclusion.java
@@ -76,11 +76,11 @@ public class CharInclusion implements BaseNonRelationalValueDomain<CharInclusion
 
 	@Override
 	public boolean lessOrEqualAux(CharInclusion other) throws SemanticException {
-		if (this.certainlyContained.size() > other.certainlyContained.size() ||
+		if (other.certainlyContained.size() > this.certainlyContained.size() ||
 				this.maybeContained.size() > other.maybeContained.size())
 			return false;
 
-		if (!other.certainlyContained.containsAll(this.certainlyContained))
+		if (!this.certainlyContained.containsAll(other.certainlyContained))
 			return false;
 
 		return other.maybeContained.containsAll(this.maybeContained);

--- a/lisa/lisa-analyses/src/test/java/it/unive/lisa/analysis/string/CharInclusionTest.java
+++ b/lisa/lisa-analyses/src/test/java/it/unive/lisa/analysis/string/CharInclusionTest.java
@@ -74,17 +74,17 @@ public class CharInclusionTest {
 
 		certainlyContained.add('a');
 		certainlyContained.add('b');
+		certainlyContained.add('c');
+		certainlyContained.add('d');
 
 		otherCertainlyContained.add('a');
 		otherCertainlyContained.add('b');
-		otherCertainlyContained.add('c');
-		otherCertainlyContained.add('d');
+
+		maybeContained.add('h');
 
 		otherMaybeContained.add('f');
 		otherMaybeContained.add('g');
 		otherMaybeContained.add('h');
-
-		maybeContained.add('h');
 
 		assertTrue(new CharInclusion(certainlyContained, maybeContained)
 				.lessOrEqualAux(new CharInclusion(otherCertainlyContained, otherMaybeContained)));


### PR DESCRIPTION
**Description**
With this PR I fixed the lessOrEqualAux method and its test, which were implemented wrongly.
Indeed, the partial order for this domain is defined as:

otherCertainlyContained is a subset of thisCertainlyContained
thisMaybeContained is a subset of otherMaybeContained
