### PR TITLE
Fix type-checking errors in Addition and Remainder statements.

### DIFF
--- a/lisa/lisa-program/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Addition.java
+++ b/lisa/lisa-program/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Addition.java
@@ -55,7 +55,7 @@ public class Addition extends it.unive.lisa.program.cfg.statement.BinaryExpressi
 			SymbolicExpression right,
 			StatementStore<A> expressions)
 			throws SemanticException {
-		if (state.getState().getRuntimeTypesOf(right, this, state.getState()).stream().noneMatch(Type::isNumericType))
+		if (state.getState().getRuntimeTypesOf(left, this, state.getState()).stream().noneMatch(Type::isNumericType))
 			return state.bottom();
 		if (state.getState().getRuntimeTypesOf(right, this, state.getState()).stream().noneMatch(Type::isNumericType))
 			return state.bottom();

--- a/lisa/lisa-program/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Remainder.java
+++ b/lisa/lisa-program/src/main/java/it/unive/lisa/program/cfg/statement/numeric/Remainder.java
@@ -58,7 +58,7 @@ public class Remainder extends it.unive.lisa.program.cfg.statement.BinaryExpress
 			throws SemanticException {
 		if (state.getState().getRuntimeTypesOf(left, this, state.getState()).stream().noneMatch(Type::isNumericType))
 			return state.bottom();
-		if (state.getState().getRuntimeTypesOf(left, this, state.getState()).stream().noneMatch(Type::isNumericType))
+		if (state.getState().getRuntimeTypesOf(right, this, state.getState()).stream().noneMatch(Type::isNumericType))
 			return state.bottom();
 
 		return state.smallStepSemantics(


### PR DESCRIPTION
**Description**
It addresses type-checking errors in the Addition and Remainder statements. Specifically, it fixes issues related to incorrect type-checking conditions in the code where only one expression (either left or right) was being checked at a time instead of both.

**Fixed bugs**
- Fix type-checking errors in Addition statement: ensure both left and right expressions are checked for type compatibility.
- Fix type-checking errors in Remainder statement: ensure both left and right expressions are checked for type compatibility.

**Implemented features**
None.

**Further content**
None.
