### PR TITLE
Add assumeBinaryExpression for StringConstantPropagation and BoundedStringSet

### DIFF
--- a/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/BoundedStringSet.java
+++ b/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/BoundedStringSet.java
@@ -5,11 +5,13 @@ import it.unive.lisa.analysis.SemanticOracle;
 import it.unive.lisa.analysis.combination.constraints.WholeValueElement;
 import it.unive.lisa.analysis.combination.constraints.WholeValueStringDomain;
 import it.unive.lisa.analysis.combination.smash.SmashedSumStringDomain;
+import it.unive.lisa.analysis.nonrelational.value.ValueEnvironment;
 import it.unive.lisa.lattices.Satisfiability;
 import it.unive.lisa.lattices.SetLattice;
 import it.unive.lisa.program.cfg.ProgramPoint;
 import it.unive.lisa.symbolic.value.BinaryExpression;
 import it.unive.lisa.symbolic.value.Constant;
+import it.unive.lisa.symbolic.value.Identifier;
 import it.unive.lisa.symbolic.value.TernaryExpression;
 import it.unive.lisa.symbolic.value.UnaryExpression;
 import it.unive.lisa.symbolic.value.ValueExpression;
@@ -17,6 +19,7 @@ import it.unive.lisa.symbolic.value.operator.binary.BinaryOperator;
 import it.unive.lisa.symbolic.value.operator.binary.ComparisonEq;
 import it.unive.lisa.symbolic.value.operator.binary.ComparisonGe;
 import it.unive.lisa.symbolic.value.operator.binary.ComparisonLe;
+import it.unive.lisa.symbolic.value.operator.binary.ComparisonNe;
 import it.unive.lisa.symbolic.value.operator.binary.StringConcat;
 import it.unive.lisa.symbolic.value.operator.binary.StringContains;
 import it.unive.lisa.symbolic.value.operator.binary.StringEndsWith;
@@ -510,6 +513,57 @@ public class BoundedStringSet
 			throw new SemanticException("Cannot convert stirng indexof bound to int", e1);
 		}
 		return constr;
+	}
+
+	@Override
+	public ValueEnvironment<BSS> assumeBinaryExpression(
+			ValueEnvironment<BSS> environment,
+			BinaryExpression expression,
+			ProgramPoint src,
+			ProgramPoint dest,
+			SemanticOracle oracle)
+			throws SemanticException {
+		BinaryOperator operator = expression.getOperator();
+		if (operator != ComparisonEq.INSTANCE && operator != ComparisonNe.INSTANCE)
+			return environment;
+
+		ValueExpression left = (ValueExpression) expression.getLeft();
+		ValueExpression right = (ValueExpression) expression.getRight();
+		Identifier id;
+		BSS rhsVal;
+		if (left instanceof Identifier) {
+			id = (Identifier) left;
+			rhsVal = eval(environment, right, src, oracle);
+		} else if (right instanceof Identifier) {
+			id = (Identifier) right;
+			rhsVal = eval(environment, left, src, oracle);
+		} else {
+			return environment;
+		}
+
+		if (rhsVal.isTop() || rhsVal.isBottom())
+			return environment;
+
+		BSS lhsVal = environment.getState(id);
+		if (operator == ComparisonEq.INSTANCE) {
+			BSS refined = lhsVal.glb(rhsVal);
+			if (refined.isBottom())
+				return environment.bottom();
+			if (!refined.equals(lhsVal))
+				return environment.putState(id, refined);
+		} else {
+			// ComparisonNe: remove rhsVal strings from lhsVal
+			if (lhsVal.isTop() || lhsVal.isBottom())
+				return environment;
+			Set<String> diff = new HashSet<>(lhsVal.elements);
+			diff.removeAll(rhsVal.elements);
+			BSS refined = top().mk(diff);
+			if (refined.isBottom())
+				return environment.bottom();
+			if (!refined.equals(lhsVal))
+				return environment.putState(id, refined);
+		}
+		return environment;
 	}
 
 	@Override

--- a/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/StringConstantPropagation.java
+++ b/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/string/StringConstantPropagation.java
@@ -1,15 +1,19 @@
 package it.unive.lisa.analysis.string;
 
 import it.unive.lisa.analysis.BaseLattice;
+import it.unive.lisa.analysis.SemanticException;
 import it.unive.lisa.analysis.SemanticOracle;
 import it.unive.lisa.analysis.nonrelational.value.BaseNonRelationalValueDomain;
+import it.unive.lisa.analysis.nonrelational.value.ValueEnvironment;
 import it.unive.lisa.lattices.Satisfiability;
 import it.unive.lisa.lattices.string.StringConstant;
 import it.unive.lisa.program.cfg.ProgramPoint;
 import it.unive.lisa.symbolic.value.BinaryExpression;
 import it.unive.lisa.symbolic.value.Constant;
+import it.unive.lisa.symbolic.value.Identifier;
 import it.unive.lisa.symbolic.value.TernaryExpression;
 import it.unive.lisa.symbolic.value.UnaryExpression;
+import it.unive.lisa.symbolic.value.ValueExpression;
 import it.unive.lisa.symbolic.value.operator.binary.BinaryOperator;
 import it.unive.lisa.symbolic.value.operator.binary.ComparisonEq;
 import it.unive.lisa.symbolic.value.operator.binary.ComparisonGe;
@@ -119,6 +123,45 @@ public class StringConstantPropagation
 
 		else
 			return Satisfiability.UNKNOWN;
+	}
+
+	@Override
+	public ValueEnvironment<StringConstant> assumeBinaryExpression(
+			ValueEnvironment<StringConstant> environment,
+			BinaryExpression expression,
+			ProgramPoint src,
+			ProgramPoint dest,
+			SemanticOracle oracle)
+			throws SemanticException {
+		Satisfiability sat = satisfies(environment, expression, src, oracle);
+		if (sat == Satisfiability.NOT_SATISFIED)
+			return environment.bottom();
+		if (sat == Satisfiability.SATISFIED)
+			return environment;
+
+		BinaryOperator operator = expression.getOperator();
+		ValueExpression left = (ValueExpression) expression.getLeft();
+		ValueExpression right = (ValueExpression) expression.getRight();
+		if (operator == ComparisonEq.INSTANCE) {
+			if (left instanceof Identifier) {
+				StringConstant eval = eval(environment, right, src, oracle);
+				if (eval.isBottom())
+					return environment.bottom();
+				// If eval is TOP, the rhs is unknown. Any abstract value of lhs
+				// satisfies lhs == TOP, so the lhs abstract value is preserved
+				// and no refinement is needed.
+				if (!eval.isTop())
+					return environment.putState((Identifier) left, eval);
+			} else if (right instanceof Identifier) {
+				StringConstant eval = eval(environment, left, src, oracle);
+				if (eval.isBottom())
+					return environment.bottom();
+				// Same reasoning as above, symmetric case.
+				if (!eval.isTop())
+					return environment.putState((Identifier) right, eval);
+			}
+		}
+		return environment;
 	}
 
 	@Override


### PR DESCRIPTION
**Description**                                                                                                                                               
  Implements `assumeBinaryExpression` for both string analysis domains, enabling path-sensitive refinement of string variables under equality and inequality constraints.                                                                                                                                                  
                                                                                                                                                                
- **`StringConstantPropagation`**: overrides `assumeBinaryExpression` to handle `==` assumptions. When a variable is constrained to equal a known string constant, the environment is updated to reflect that binding. Contradictions (constraints that can never be satisfied) return `bottom`. 
                                                            
 - **`BoundedStringSet`**: overrides `assumeBinaryExpression` to handle both `==` and `!=` assumptions. For equality, the variable's abstract value is refined via `glb` with the right-hand side. For inequality, the known strings on the right-hand side are subtracted from the variable's current set (e.g., `{"alpha", "beta"} != "alpha"` refines to `{"beta"}`). Both cases return `bottom` when the refined value is empty.                                                       
                                                            
  **Fixed bugs**

  None.

  **Implemented features**

  - `assumeBinaryExpression` for String                                                                                                                         
   
  **Further content**                                                                                                                                           
                                                            
 None.  