### PR TITLE
Fix unsound multiplication in Sign domain

### DIFF
--- a/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/numeric/Sign.java
+++ b/lisa/lisa-analyses/src/main/java/it/unive/lisa/analysis/numeric/Sign.java
@@ -118,6 +118,8 @@ public class Sign
 		else if (operator instanceof MultiplicationOperator)
 			if (left.isZero() || right.isZero())
 				return SignLattice.ZERO;
+			else if (left.isTop() || right.isTop())
+				return top();
 			else if (left.equals(right))
 				return SignLattice.POS;
 			else


### PR DESCRIPTION
**Description**
When evaluating a binary expression with a MultiplicationOperator, if both operands are TOP, the implementation of the Sign Domain incorrectly returns +. However, since TOP represents any value (+, −, or 0), TOP × TOP should return TOP. 
Similarly, if only one operand is TOP, the implementation retruns −, but TOP × + ≠ −. 

**Fixed bugs**
No open issue related to this bug.

**Implemented features**
Added an isTop() guard: if either operand is TOP, the operation now returns TOP.

**Further content**
None.
