### PR TITLE
#362 Decouple FixpointInfo from ProgramState lattice-level operations

### DIFF
--- a/lisa/lisa-analyses/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
+++ b/lisa/lisa-analyses/src/test/java/it/unive/lisa/program/cfg/SemanticsSanityTest.java
@@ -196,10 +196,11 @@ public class SemanticsSanityTest {
 					res = ((Pair) res).getLeft();
 				boolean isBottom = ((Lattice) res).isBottom();
 				if (res instanceof AnalysisState) {
+					// note: getExecutionInformation() is decoupled from the
+					// lattice structure and does not contribute to the bottom
+					// check.
 					AnalysisState state = (AnalysisState) res;
 					isBottom = state.getExecutionState().isBottom()
-							&& state.getExecutionInformation() != null
-							&& state.getExecutionInformation().isBottom()
 							// analysis state keeps the assigned id on the stack
 							&& state.getExecutionExpressions().size() == 1
 							&& state.getExecutionExpressions().iterator().next().equals(v);

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/AnalysisState.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/AnalysisState.java
@@ -235,6 +235,17 @@ public class AnalysisState<A extends AbstractLattice<A>>
 	}
 
 	/**
+	 * Yields a copy of this state where the additional fixpoint information
+	 * ({@link #getExecutionInformation()}) of the normal execution has been
+	 * removed.
+	 *
+	 * @return a new instance with an empty execution fixpoint info.
+	 */
+	public AnalysisState<A> clearExecutionInfo() {
+		return new AnalysisState<>(execution.clearInfo(), halt, smashedErrors, smashedErrorsState, errors);
+	}
+
+	/**
 	 * Yields the program state corresponding to the normal execution. This is
 	 * the state that represents the program's normal behavior during its
 	 * execution, and it is the only one that evolves through assignments,

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/ProgramState.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/analysis/ProgramState.java
@@ -201,6 +201,20 @@ public class ProgramState<A extends AbstractLattice<A>>
 	}
 
 	/**
+	 * Yields a copy of this state without the additional fixpoint information
+	 * ({@link #getFixpointInformation()}). All entries are removed, regardless
+	 * of their key. To update individual entries, use
+	 * {@link #storeInfo(String, Lattice)} or
+	 * {@link #weakStoreInfo(String, Lattice)}.
+	 *
+	 * @return a new instance with an empty {@link FixpointInfo}
+	 */
+
+	public ProgramState<A> clearInfo() {
+		return new ProgramState<>(state, computedExpressions, FixpointInfo.BOTTOM);
+	}
+
+	/**
 	 * Yields the last computed expression. This is an instance of
 	 * {@link SymbolicExpression} that will contain markers for all abstract
 	 * values that would be present on the stack, as well as variable
@@ -352,22 +366,22 @@ public class ProgramState<A extends AbstractLattice<A>>
 
 	@Override
 	public ProgramState<A> top() {
-		return new ProgramState<>(state.top(), computedExpressions.top(), info.top());
+		return new ProgramState<>(state.top(), computedExpressions.top(), info);
 	}
 
 	@Override
 	public ProgramState<A> bottom() {
-		return new ProgramState<>(state.bottom(), computedExpressions.bottom(), FixpointInfo.BOTTOM);
+		return new ProgramState<>(state.bottom(), computedExpressions.bottom(), info);
 	}
 
 	@Override
 	public boolean isTop() {
-		return state.isTop() && computedExpressions.isTop() && info.isTop();
+		return state.isTop() && computedExpressions.isTop();
 	}
 
 	@Override
 	public boolean isBottom() {
-		return state.isBottom() && computedExpressions.isBottom() && info.isBottom();
+		return state.isBottom() && computedExpressions.isBottom();
 	}
 
 	@Override


### PR DESCRIPTION
**Description**

Decouples FixpointInfo from the lattice-level methods of ProgramState. 
top() and bottom() now preserve the current fixpoint information instead of resetting it.
 isTop() and isBottom() no longer include FixpointInfo in their checks.

**Fixed bugs**
None.

**Implemented features**
#362

**Further content**
clearInfo() and clearExecutionInfo() methods are added respectively to the ProgramState and AnalysisState to explicitly discard all fixpoint information when needed. The semantic sanity checks are updated to reflect that getExecutionInformation() of AnalysisState (which is implemented by delegating ProgramState.getFixpointInformation()) is decoupled from the lattice structure.
