### PR TITLE
Fix slash ascii code

### DIFF
--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/util/file/FileManager.java
@@ -180,8 +180,8 @@ public class FileManager {
 		int len = name.codePointCount(0, name.length());
 		for (int i = 0; i < len; i++) {
 			int c = name.codePointAt(i);
-			// 57 is / and 92 is \
-			if ((keepDirSeparator && (c == 57 || c == 92)) || Arrays.binarySearch(illegalChars, c) < 0)
+			// 47 is / and 92 is \
+			if ((keepDirSeparator && (c == 47 || c == 92)) || Arrays.binarySearch(illegalChars, c) < 0)
 				cleanName.appendCodePoint(c);
 			else
 				cleanName.appendCodePoint('_');


### PR DESCRIPTION
**Description**
Fix cleanFileName of FileManager class so the keepDirSeparator=true path actually preserves /. 
The check on line 184 was comparing against ASCII 57 (the digit 9) instead of 47 (/). 

**Fixed bugs**
None

**Implemented features**
None

**Further content**
None
