### PR TITLE
Added extra constructor for CompilationUnit

### DIFF
--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/AbstractClassUnit.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/AbstractClassUnit.java
@@ -1,5 +1,6 @@
 package it.unive.lisa.program;
 
+import it.unive.lisa.program.annotations.Annotations;
 import it.unive.lisa.program.cfg.CodeLocation;
 
 /**
@@ -16,12 +17,12 @@ public class AbstractClassUnit
 	/**
 	 * Builds a concrete compilation unit, defined at the given program point.
 	 * 
-	 * @param location the location where the unit is define within the source
+	 * @param location the location where the unit is defined within the source
 	 *                     file
 	 * @param program  the program where this unit is defined
 	 * @param name     the name of the unit
 	 * @param sealed   whether or not this unit is sealed, meaning that it
-	 *                     cannot be used as super unit of other compilation
+	 *                     cannot be used as a super unit of other compilation
 	 *                     units
 	 */
 	public AbstractClassUnit(
@@ -30,6 +31,27 @@ public class AbstractClassUnit
 			String name,
 			boolean sealed) {
 		super(location, program, name, sealed);
+	}
+
+	/**
+	 * Builds a concrete compilation unit, defined at the given program point.
+	 *
+	 * @param location    the location where the unit is defined within the
+	 *                        source file
+	 * @param program     the program where this unit is defined
+	 * @param name        the name of the unit
+	 * @param annotations the annotations associated with the unit
+	 * @param sealed      whether or not this unit is sealed, meaning that it
+	 *                        cannot be used as a super unit of other
+	 *                        compilation units
+	 */
+	public AbstractClassUnit(
+			CodeLocation location,
+			Program program,
+			String name,
+			Annotations annotations,
+			boolean sealed) {
+		super(location, program, name, annotations, sealed);
 	}
 
 	@Override

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/ClassUnit.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/ClassUnit.java
@@ -1,5 +1,6 @@
 package it.unive.lisa.program;
 
+import it.unive.lisa.program.annotations.Annotations;
 import it.unive.lisa.program.cfg.CodeLocation;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -19,7 +20,7 @@ public class ClassUnit
 
 	/**
 	 * The collection of compilation units this unit directly inherits from.
-	 * This collection may contain both concrete and abstract compilation unit.
+	 * This collection may contain both concrete and abstract compilation units.
 	 */
 	private final List<ClassUnit> superclasses;
 
@@ -31,12 +32,12 @@ public class ClassUnit
 	/**
 	 * Builds a compilation unit, defined at the given program point.
 	 * 
-	 * @param location the location where the unit is define within the source
+	 * @param location the location where the unit is defined within the source
 	 *                     file
 	 * @param program  the program where this unit is defined
 	 * @param name     the name of the unit
 	 * @param sealed   whether or not this unit is sealed, meaning that it
-	 *                     cannot be used as super unit of other compilation
+	 *                     cannot be used as a super unit of other compilation
 	 *                     units
 	 */
 	public ClassUnit(
@@ -45,6 +46,30 @@ public class ClassUnit
 			String name,
 			boolean sealed) {
 		super(location, program, name, sealed);
+		Objects.requireNonNull(location, "The location of a unit cannot be null.");
+		superclasses = new LinkedList<>();
+		interfaces = new LinkedList<>();
+	}
+
+	/**
+	 * Builds a compilation unit, defined at the given program point.
+	 *
+	 * @param location    the location where the unit is defined within the
+	 *                        source file
+	 * @param program     the program where this unit is defined
+	 * @param name        the name of the unit
+	 * @param annotations the annotations associated with the unit
+	 * @param sealed      whether or not this unit is sealed, meaning that it
+	 *                        cannot be used as a super unit of other
+	 *                        compilation units
+	 */
+	public ClassUnit(
+			CodeLocation location,
+			Program program,
+			String name,
+			Annotations annotations,
+			boolean sealed) {
+		super(location, program, name, annotations, sealed);
 		Objects.requireNonNull(location, "The location of a unit cannot be null.");
 		superclasses = new LinkedList<>();
 		interfaces = new LinkedList<>();

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/CompilationUnit.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/CompilationUnit.java
@@ -17,7 +17,7 @@ import java.util.TreeMap;
 import java.util.function.Predicate;
 
 /**
- * An unit of the program to analyze that is part of a hierarchical structure.
+ * A unit of the program to analyze that is part of a hierarchical structure.
  * 
  * @author <a href="mailto:vincenzo.arceri@unipr.it">VincenzoArceri</a>
  */
@@ -51,14 +51,14 @@ public abstract class CompilationUnit
 
 	/**
 	 * Whether or not this compilation unit is sealed, meaning that it cannot be
-	 * used as super unit of other compilation units
+	 * used as a super unit of other compilation units
 	 */
 	private final boolean sealed;
 
 	/**
-	 * Builds an unit with super unit.
+	 * Builds a unit with super unit.
 	 * 
-	 * @param location the location where the unit is define within the source
+	 * @param location the location where the unit is defined within the source
 	 *                     file
 	 * @param program  the program where this unit is defined
 	 * @param name     the name of the unit
@@ -78,8 +78,32 @@ public abstract class CompilationUnit
 	}
 
 	/**
+	 * Builds a unit with super unit.
+	 *
+	 * @param location    the location where the unit is defined within the
+	 *                        source file
+	 * @param program     the program where this unit is defined
+	 * @param name        the name of the unit
+	 * @param annotations the annotations associated with the unit
+	 * @param sealed      whether or not this unit can be inherited from
+	 */
+	protected CompilationUnit(
+			CodeLocation location,
+			Program program,
+			String name,
+			Annotations annotations,
+			boolean sealed) {
+		super(location, program, name);
+		this.annotations = annotations;
+		this.sealed = sealed;
+		instanceCodeMembers = new TreeMap<>();
+		instanceGlobals = new TreeMap<>();
+		instances = new HashSet<>();
+	}
+
+	/**
 	 * Yields whether or not this unit is sealed, meaning that it cannot be used
-	 * as super unit of other compilation units.
+	 * as a super unit of other compilation units.
 	 * 
 	 * @return {@code true} if this unit is sealed
 	 */

--- a/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/InterfaceUnit.java
+++ b/lisa/lisa-sdk/src/main/java/it/unive/lisa/program/InterfaceUnit.java
@@ -1,5 +1,6 @@
 package it.unive.lisa.program;
 
+import it.unive.lisa.program.annotations.Annotations;
 import it.unive.lisa.program.cfg.CodeLocation;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -7,7 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * A interface unit of the program to analyze. A interface unit is a
+ * An interface unit of the program to analyze. An interface unit is a
  * {@link Unit} that only defines instance members, from which other units (both
  * {@link ClassUnit} and {@link InterfaceUnit}) can inherit from
  * 
@@ -25,7 +26,7 @@ public class InterfaceUnit
 	/**
 	 * Builds an interface unit, defined at the given location.
 	 * 
-	 * @param location the location where the unit is define within the source
+	 * @param location the location where the unit is defined within the source
 	 *                     file
 	 * @param program  the program where this unit is defined
 	 * @param name     the name of the unit
@@ -37,6 +38,26 @@ public class InterfaceUnit
 			String name,
 			boolean sealed) {
 		super(location, program, name, sealed);
+		superinterfaces = new LinkedList<>();
+	}
+
+	/**
+	 * Builds an interface unit, defined at the given location.
+	 *
+	 * @param location    the location where the unit is defined within the
+	 *                        source file
+	 * @param program     the program where this unit is defined
+	 * @param name        the name of the unit
+	 * @param annotations the annotations associated with the unit
+	 * @param sealed      whether or not this unit can be inherited from
+	 */
+	public InterfaceUnit(
+			CodeLocation location,
+			Program program,
+			String name,
+			Annotations annotations,
+			boolean sealed) {
+		super(location, program, name, annotations, sealed);
 		superinterfaces = new LinkedList<>();
 	}
 


### PR DESCRIPTION
For convenience purposes, added an extra constructor for CompilationUnit (and its extensions, i.e. ClassUnit, InterfaceUnit, AbstractClassUnit) that allows to provide the collection of annotations. Plus some Javadoc wording fixes.